### PR TITLE
Qspi write txbuf race condition fixes

### DIFF
--- a/s32/drivers/s32ze/Fls/src/Qspi_Ip_Controller.c
+++ b/s32/drivers/s32ze/Fls/src/Qspi_Ip_Controller.c
@@ -1649,19 +1649,17 @@ static inline void Qspi_Ip_InvalidateTxBuf(uint32 instance)
     QuadSPI_Type *baseAddr = Qspi_Ip_BaseAddress[instance];
     volatile uint32 u32CurrentTicks;
 
-    if (Qspi_Ip_GetTxBufFill(baseAddr) != 0U) {
-        /* Start TX FIFO reset */
-        Qspi_Ip_ClearTxBuf(baseAddr);
+    /* Start TX FIFO reset */
+    Qspi_Ip_ClearTxBuf(baseAddr);
 
-        /* Prepare timeout counter */
-        u32CurrentTicks = QSPI_IP_TX_BUFFER_RESET_DELAY;
-        /* Insert delay to ensure TX FIFO reset is complete */
-        while (u32CurrentTicks > 0U)
-        {
-            u32CurrentTicks--;
-        }
-        MCAL_DATA_SYNC_BARRIER();
+    /* Prepare timeout counter */
+    u32CurrentTicks = QSPI_IP_TX_BUFFER_RESET_DELAY;
+    /* Insert delay to ensure TX FIFO reset is complete */
+    while (u32CurrentTicks > 0U)
+    {
+        u32CurrentTicks--;
     }
+    MCAL_DATA_SYNC_BARRIER();
 }
 
 

--- a/s32/soc/s32z270/include/Qspi_Ip_Features.h
+++ b/s32/soc/s32z270/include/Qspi_Ip_Features.h
@@ -53,7 +53,7 @@ extern "C"{
 /*! @brief Size of AHB buffer. */
 #define FEATURE_QSPI_AHB_BUF_SIZE                     256U
 /*! @brief Size of Tx FIFO. */
-#define FEATURE_QSPI_TX_BUF_SIZE                      128U
+#define FEATURE_QSPI_TX_BUF_SIZE                      1024U
 /*! @brief Size of Rx FIFO. */
 #define FEATURE_QSPI_RX_BUF_SIZE                      128U
 /*! @brief Number of LUT registers that make up a LUT sequence */


### PR DESCRIPTION
The hardware fifo supports 256 4byte entries for a total of 1024 bytes. This is an important value for getting the watermark calculation correct. Without this correct the hardware kicks off operations before the core completes the tx fill and ends up with an underrun fault.

For some reason the compulsory HW clear of the tx fifo buffer (even when its empty) reduces the occurrences of sporadically observed underrun faults, so always clear that here too.